### PR TITLE
Add scheduled Slack notifications

### DIFF
--- a/src/main/java/com/SKALA/LikeCloudy/LikeCloudyApplication.java
+++ b/src/main/java/com/SKALA/LikeCloudy/LikeCloudyApplication.java
@@ -2,8 +2,10 @@ package com.SKALA.LikeCloudy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class LikeCloudyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/SKALA/LikeCloudy/Service/ScheduleService.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Service/ScheduleService.java
@@ -1,0 +1,31 @@
+package com.SKALA.LikeCloudy.Service;
+
+import com.SKALA.LikeCloudy.DTO.VoteSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final SlackMessageService slackMessageService;
+    private final HystecMenuService hystecMenuService;
+    private final ResultService resultService;
+
+    @Scheduled(cron = "0 30 10 * * *")
+    public void sendMenuGuideMessage() {
+        String menuMessage = hystecMenuService.formatBundangBiwonLunchForSlack(
+                hystecMenuService.fetchBundangBiwonLunch(LocalDate.now()));
+        slackMessageService.sendMessage(menuMessage);
+    }
+
+    @Scheduled(cron = "0 30 11 * * *")
+    public void sendVoteResultMessage() {
+        VoteSummaryResponse summary = resultService.getVoteSummary(LocalDate.now());
+        String message = resultService.formatSummaryForSlack(summary);
+        slackMessageService.sendMessage(message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,9 +34,14 @@ spring:
     locale: ko_KR
     locale-resolver: fixed
 
+  task:
+    scheduling:
+      pool:
+        size: 10
+
 
 slack:
-  bot-token: -
+  bot-token: "-"
   signing-secret: ${SLACK_SIGNING_SECRET}
   postMessageUrl: "https://slack.com/api/chat.postMessage"
   channel:


### PR DESCRIPTION
## Summary
- enable Spring scheduling in the main application
- send daily menu guide and vote results to Slack on a schedule
- configure a scheduling thread pool for reliable cron execution

## Testing
- `./gradlew test` *(fails: Unable to open JDBC Connection for DDL execution)*

------
https://chatgpt.com/codex/tasks/task_e_68b7eb34375c83209d543f9da519fec8