### PR TITLE
feat: use Block Kit for Slack vote results

### DIFF
--- a/src/main/java/com/SKALA/LikeCloudy/Controller/SlackController.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Controller/SlackController.java
@@ -102,10 +102,10 @@ public class SlackController {
     [GET] /slack/result -> 오늘의 투표 결과를 Slack 메세지 형식으로 반환
      */
     @GetMapping("/result")
-    public ResponseEntity<String> getTodayVoteResult() {
+    public ResponseEntity<List<Map<String, Object>>> getTodayVoteResult() {
         VoteSummaryResponse summary = resultService.getVoteSummary(LocalDate.now());
-        String message = resultService.formatSummaryForSlack(summary);
-        return ResponseEntity.ok(message);
+        List<Map<String, Object>> blocks = resultService.formatSummaryForSlack(summary);
+        return ResponseEntity.ok(blocks);
     }
 
     @GetMapping("/result/send")

--- a/src/main/java/com/SKALA/LikeCloudy/Service/SlackMessageService.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Service/SlackMessageService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -24,16 +25,21 @@ public class SlackMessageService {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    public void sendMessage(String text) {
+    /**
+     * Send a message to Slack using Block Kit structure.
+     *
+     * @param blocks List of Block Kit blocks
+     */
+    public void sendMessage(List<Map<String, Object>> blocks) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(botToken); // Authorization: Bearer xoxb-...
 
-        Map<String, String> body = new HashMap<>();
+        Map<String, Object> body = new HashMap<>();
         body.put("channel", defaultChannel);
-        body.put("text", text);
+        body.put("blocks", blocks);
 
-        HttpEntity<Map<String, String>> entity = new HttpEntity<>(body, headers);
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
 
         ResponseEntity<String> response = restTemplate.postForEntity(postMessageUrl, entity, String.class);
 

--- a/src/main/java/com/SKALA/LikeCloudy/Slack/SlackBlockBuilder.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Slack/SlackBlockBuilder.java
@@ -1,0 +1,43 @@
+package com.SKALA.LikeCloudy.Slack;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple builder to help construct Slack Block Kit structures.
+ */
+public class SlackBlockBuilder {
+    private final List<Map<String, Object>> blocks = new ArrayList<>();
+
+    /**
+     * Adds a section block with mrkdwn text.
+     */
+    public SlackBlockBuilder section(String text) {
+        Map<String, Object> section = new HashMap<>();
+        section.put("type", "section");
+
+        Map<String, String> textObj = new HashMap<>();
+        textObj.put("type", "mrkdwn");
+        textObj.put("text", text);
+        section.put("text", textObj);
+
+        blocks.add(section);
+        return this;
+    }
+
+    /**
+     * Adds a divider block.
+     */
+    public SlackBlockBuilder divider() {
+        Map<String, Object> divider = new HashMap<>();
+        divider.put("type", "divider");
+        blocks.add(divider);
+        return this;
+    }
+
+    public List<Map<String, Object>> build() {
+        return blocks;
+    }
+}


### PR DESCRIPTION
## Summary
- build Slack block messages with helper SlackBlockBuilder
- send Block Kit blocks instead of text
- format vote results as Slack blocks

## Testing
- `./gradlew test` *(fails: `contextLoads()` due to YAML ScannerException)*


------
https://chatgpt.com/codex/tasks/task_e_68b7f5d7e4208320a9326650eb726f82