### PR TITLE
feat: add scheduled menu and vote notifications

### DIFF
--- a/src/main/java/com/SKALA/LikeCloudy/LikeCloudyApplication.java
+++ b/src/main/java/com/SKALA/LikeCloudy/LikeCloudyApplication.java
@@ -2,8 +2,10 @@ package com.SKALA.LikeCloudy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class LikeCloudyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/SKALA/LikeCloudy/Service/ScheduleService.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Service/ScheduleService.java
@@ -1,0 +1,35 @@
+package com.SKALA.LikeCloudy.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final SlackMessageService slackMessageService;
+    private final HystecMenuService hystecMenuService;
+    private final ResultService resultService;
+
+    /**
+     * 오전 10시 30분에 오늘의 메뉴 안내 메시지를 전송합니다.
+     */
+    @Scheduled(cron = "0 30 10 * * *")
+    public void sendMenuGuide() {
+        String message = hystecMenuService.formatBundangBiwonLunchForSlack(
+                hystecMenuService.fetchBundangBiwonLunch(LocalDate.now()));
+        slackMessageService.sendMessage(message);
+    }
+
+    /**
+     * 오전 11시 30분에 투표 결과를 전송합니다.
+     */
+    @Scheduled(cron = "0 30 11 * * *")
+    public void sendVoteResult() {
+        resultService.sendTodaySummaryToSlack();
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,13 +34,18 @@ spring:
     locale: ko_KR
     locale-resolver: fixed
 
+  task:
+    scheduling:
+      pool:
+        size: 2
+
 
 slack:
   bot-token: -
   signing-secret: ${SLACK_SIGNING_SECRET}
   postMessageUrl: "https://slack.com/api/chat.postMessage"
-  channel:
-    monitor: "#일반"
+    channel:
+      monitor: "#일반"
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- enable scheduling support
- send daily menu and vote results to Slack via scheduled tasks
- configure scheduling thread pool size

## Testing
- `./gradlew test` *(fails: Could not resolve Java toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f5cf34ac832089e1e544aa1f0526