### PR TITLE
Use Block Kit for menu guide

### DIFF
--- a/src/main/java/com/SKALA/LikeCloudy/Service/ScheduleService.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Service/ScheduleService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 
+import com.SKALA.LikeCloudy.Slack.SlackBlockBuilder;
+
 @Service
 @RequiredArgsConstructor
 public class ScheduleService {
@@ -21,7 +23,11 @@ public class ScheduleService {
     public void sendMenuGuide() {
         String message = hystecMenuService.formatBundangBiwonLunchForSlack(
                 hystecMenuService.fetchBundangBiwonLunch(LocalDate.now()));
-        slackMessageService.sendMessage(message);
+
+        SlackBlockBuilder builder = new SlackBlockBuilder();
+        builder.section(message);
+
+        slackMessageService.sendMessage(builder.build());
     }
 
     /**


### PR DESCRIPTION
## Summary
- format lunch menu into a Slack Block Kit section block and send via SlackMessageService

## Testing
- `bash ./gradlew test` *(fails: Could not determine dependencies; missing Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f97c55ec8320a2a5759c8cfc7fbd