### PR TITLE
refactor: unify Slack messaging service

### DIFF
--- a/src/main/java/com/SKALA/LikeCloudy/Controller/SlackController.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Controller/SlackController.java
@@ -22,13 +22,13 @@ public class SlackController {
     private final MenuService menuService;
     private final VoteService voteService;
     private final ResultService resultService;
-    private final SlackService slackService;
+    private final SlackMessageService slackMessageService;
     private final HystecMenuService hystecMenuService;
     private final SlackEventService slackEventService;
 
     @GetMapping("/test")
     public String sendSlackTest() {
-        slackService.sendMessage("테스트 메시지입니다! 👋");
+        slackMessageService.sendMessage("테스트 메시지입니다! 👋");
         return "Message Attempted";
     }
 
@@ -118,7 +118,7 @@ public class SlackController {
     public ResponseEntity<String> bundangLunch() {
         var res = hystecMenuService.fetchBundangBiwonLunch(LocalDate.now());
         String msg = hystecMenuService.formatBundangBiwonLunchForSlack(res);
-        // slackService.sendMessage(msg); // 원하면 전송
+        // slackMessageService.sendMessage(msg); // 원하면 전송
         return ResponseEntity.ok(msg);
     }
 

--- a/src/main/java/com/SKALA/LikeCloudy/Service/ResultService.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Service/ResultService.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 public class ResultService {
     private final MenuRepository menuRepository;
     private final VoteRepository voteRepository;
-    private final SlackService slackService;
+    private final SlackMessageService slackMessageService;
 
     public VoteSummaryResponse getVoteSummary(LocalDate date) {
         // 오늘 날짜의 모든 메뉴를 조회합니다!
@@ -64,6 +64,6 @@ public class ResultService {
     public void sendTodaySummaryToSlack() {
         VoteSummaryResponse summary = getVoteSummary(LocalDate.now());
         List<Map<String, Object>> blocks = formatSummaryForSlack(summary);
-        slackService.sendMessage(blocks);
+        slackMessageService.sendMessage(blocks);
     }
 }

--- a/src/main/java/com/SKALA/LikeCloudy/Service/ScheduleService.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Service/ScheduleService.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class ScheduleService {
 
-    private final SlackService slackService;
+    private final SlackMessageService slackMessageService;
     private final HystecMenuService hystecMenuService;
     private final ResultService resultService;
 
@@ -21,7 +21,7 @@ public class ScheduleService {
     public void sendMenuGuide() {
         String message = hystecMenuService.formatBundangBiwonLunchForSlack(
                 hystecMenuService.fetchBundangBiwonLunch(LocalDate.now()));
-        slackService.sendMessage(message);
+        slackMessageService.sendMessage(message);
     }
 
     /**

--- a/src/main/java/com/SKALA/LikeCloudy/Service/SlackMessageService.java
+++ b/src/main/java/com/SKALA/LikeCloudy/Service/SlackMessageService.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
-public class SlackService {
+public class SlackMessageService {
 
     private final Slack slack = Slack.getInstance();
 


### PR DESCRIPTION
## Summary
- rename SlackService to SlackMessageService and update references
- schedule menu guide with single cron using SlackMessageService
- send vote summaries via SlackMessageService

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68b80efe09c08320bdfd4d8cd05f0eab